### PR TITLE
Enable multi-user books

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Authorization: Bearer <token>
 ```
 
 User registration remains open at `POST /api/users`.
+
+### Books
+
+Authenticated users can manage books:
+
+- `POST /api/books` – create a new book by providing a `title`.
+- `POST /api/books/{id}/users/{userId}` – add a user to a book.
+- `GET /api/books/{id}` – retrieve a book with its members.

--- a/controllers/book_controller.go
+++ b/controllers/book_controller.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	"RaiJaiAPI_Golang/database"
+	"RaiJaiAPI_Golang/models"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CreateBook godoc
+// @Summary Create a new book
+// @Description สร้างหนังสือใหม่
+// @Tags books
+// @Accept json
+// @Produce json
+// @Param book body models.BookCreateRequest true "Book JSON"
+// @Success 201 {object} models.JsonResponse
+// @Router /api/books [post]
+func CreateBook(c *gin.Context) {
+	var req models.BookCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.JsonResponse{Success: false, Message: "Invalid request data."})
+		return
+	}
+
+	book := models.Book{Title: req.Title}
+	if err := database.DB.Create(&book).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to create book."})
+		return
+	}
+
+	c.JSON(http.StatusCreated, models.JsonResponse{Success: true, Message: "Book created successfully.", Data: book})
+}
+
+// GetBook godoc
+// @Summary Get a book by ID
+// @Description ดึงข้อมูลหนังสือตาม ID
+// @Tags books
+// @Produce json
+// @Param id path int true "Book ID"
+// @Success 200 {object} models.JsonResponse
+// @Router /api/books/{id} [get]
+func GetBook(c *gin.Context) {
+	id := c.Param("id")
+	var book models.Book
+	if err := database.DB.Preload("Users").First(&book, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.JsonResponse{Success: false, Message: "Book not found."})
+		return
+	}
+	c.JSON(http.StatusOK, models.JsonResponse{Success: true, Message: "Book retrieved successfully.", Data: book})
+}
+
+// AddUserToBook godoc
+// @Summary Add a user to a book
+// @Description เพิ่มผู้ใช้เข้าเล่มหนังสือ
+// @Tags books
+// @Produce json
+// @Param id path int true "Book ID"
+// @Param userId path int true "User ID"
+// @Success 200 {object} models.JsonResponse
+// @Router /api/books/{id}/users/{userId} [post]
+func AddUserToBook(c *gin.Context) {
+	bookID := c.Param("id")
+	userID := c.Param("userId")
+
+	var book models.Book
+	if err := database.DB.First(&book, bookID).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.JsonResponse{Success: false, Message: "Book not found."})
+		return
+	}
+
+	var user models.User
+	if err := database.DB.First(&user, userID).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.JsonResponse{Success: false, Message: "User not found."})
+		return
+	}
+
+	if err := database.DB.Model(&book).Association("Users").Append(&user); err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to add user to book."})
+		return
+	}
+
+	if err := database.DB.Preload("Users").First(&book, bookID).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to retrieve book."})
+		return
+	}
+
+	c.JSON(http.StatusOK, models.JsonResponse{Success: true, Message: "User added to book.", Data: book})
+}

--- a/database/db.go
+++ b/database/db.go
@@ -12,12 +12,12 @@ import (
 var DB *gorm.DB
 
 func ConnectDB() {
-    dsn := config.GetDSN()
-    db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-    if err != nil {
-        log.Fatal("Failed to connect to database:", err)
-    }
+	dsn := config.GetDSN()
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Fatal("Failed to connect to database:", err)
+	}
 
-    db.AutoMigrate(&models.User{}, &models.Type{}, &models.Category{}, &models.Transaction{})
-    DB = db
+	db.AutoMigrate(&models.User{}, &models.Type{}, &models.Category{}, &models.Transaction{}, &models.Book{})
+	DB = db
 }

--- a/models/book.go
+++ b/models/book.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Book struct {
+	ID        uint   `gorm:"primaryKey"`
+	Title     string `gorm:"size:100;not null"`
+	Users     []User `gorm:"many2many:book_users"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index" swaggerignore:"true"`
+}
+
+type BookCreateRequest struct {
+	Title string `json:"title" binding:"required"`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -7,22 +7,23 @@ import (
 )
 
 type User struct {
-    ID        uint           `gorm:"primaryKey"`
-    Name      string         `gorm:"size:100;unique;not null"`
-    Email     string         `gorm:"size:100;not null"`
-    Password  string         `gorm:"not null"`
-    CreatedAt time.Time
-    UpdatedAt time.Time
-    DeletedAt gorm.DeletedAt `gorm:"index" swaggerignore:"true"`
+	ID        uint   `gorm:"primaryKey"`
+	Name      string `gorm:"size:100;unique;not null"`
+	Email     string `gorm:"size:100;not null"`
+	Password  string `gorm:"not null"`
+	Books     []Book `gorm:"many2many:book_users"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index" swaggerignore:"true"`
 }
 
 type UserCreateRequest struct {
-    Name     string `json:"name" binding:"required,max=100"`
-    Email    string `json:"email" binding:"required,email,max=100"`
-    Password string `json:"password" binding:"required,min=4,max=50"`
+	Name     string `json:"name" binding:"required,max=100"`
+	Email    string `json:"email" binding:"required,email,max=100"`
+	Password string `json:"password" binding:"required,min=4,max=50"`
 }
 
 type UserUpdateRequest struct {
-    Email    string `json:"email" binding:"email,max=100"`
-    Password string `json:"password" binding:"min=4,max=50"`
+	Email    string `json:"email" binding:"email,max=100"`
+	Password string `json:"password" binding:"min=4,max=50"`
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -8,51 +8,58 @@ import (
 )
 
 func SetupRoutes(r *gin.Engine) {
-    r.GET("/ping", func(c *gin.Context) {
-        c.JSON(200, gin.H{"message": "pong"})
-    })
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "pong"})
+	})
 
-    public := r.Group("/api")
-    {
-        public.POST("/auth/login", controllers.Login)
-        public.POST("/auth/register", controllers.Register)
-    }
+	public := r.Group("/api")
+	{
+		public.POST("/auth/login", controllers.Login)
+		public.POST("/auth/register", controllers.Register)
+	}
 
-    auth := r.Group("/api")
-    auth.Use(middleware.AuthMiddleware())
+	auth := r.Group("/api")
+	auth.Use(middleware.AuthMiddleware())
 
-    user := auth.Group("/users")
-    {
-        user.GET("/", controllers.GetUsers)
-        user.PUT("/:id", controllers.UpdateUser)
-        user.DELETE("/:id", controllers.DeleteUser)
-        user.GET("/:id", controllers.GetUserByID)
-    }
+	user := auth.Group("/users")
+	{
+		user.GET("/", controllers.GetUsers)
+		user.PUT("/:id", controllers.UpdateUser)
+		user.DELETE("/:id", controllers.DeleteUser)
+		user.GET("/:id", controllers.GetUserByID)
+	}
 
-    typeGroup := auth.Group("/types")
-    {
-        typeGroup.GET("/", controllers.GetTypes)
-        typeGroup.POST("/", controllers.CreateType)
-        typeGroup.PUT("/:id", controllers.UpdateType)
-        typeGroup.DELETE("/:id", controllers.DeleteType)
-        typeGroup.GET("/:id", controllers.GetTypeByID)
-    }
+	typeGroup := auth.Group("/types")
+	{
+		typeGroup.GET("/", controllers.GetTypes)
+		typeGroup.POST("/", controllers.CreateType)
+		typeGroup.PUT("/:id", controllers.UpdateType)
+		typeGroup.DELETE("/:id", controllers.DeleteType)
+		typeGroup.GET("/:id", controllers.GetTypeByID)
+	}
 
-    category := auth.Group("/categories")
-    {
-        category.GET("/", controllers.GetCategories)
-        category.POST("/", controllers.CreateCategory)
-        category.PUT("/:id", controllers.UpdateCategory)
-        category.DELETE("/:id", controllers.DeleteCategory)
-        category.GET("/:id", controllers.GetCategory)
-    }
+	category := auth.Group("/categories")
+	{
+		category.GET("/", controllers.GetCategories)
+		category.POST("/", controllers.CreateCategory)
+		category.PUT("/:id", controllers.UpdateCategory)
+		category.DELETE("/:id", controllers.DeleteCategory)
+		category.GET("/:id", controllers.GetCategory)
+	}
 
-    transaction := auth.Group("/transactions")
-    {
-        transaction.GET("/", controllers.GetTransactions)
-        transaction.POST("/", controllers.CreateTransaction)
-        transaction.PUT("/:id", controllers.UpdateTransaction)
-        transaction.DELETE("/:id", controllers.DeleteTransaction)
-        transaction.GET("/:id", controllers.GetTransaction)
-    }
+	transaction := auth.Group("/transactions")
+	{
+		transaction.GET("/", controllers.GetTransactions)
+		transaction.POST("/", controllers.CreateTransaction)
+		transaction.PUT("/:id", controllers.UpdateTransaction)
+		transaction.DELETE("/:id", controllers.DeleteTransaction)
+		transaction.GET("/:id", controllers.GetTransaction)
+	}
+
+	book := auth.Group("/books")
+	{
+		book.POST("/", controllers.CreateBook)
+		book.GET("/:id", controllers.GetBook)
+		book.POST("/:id/users/:userId", controllers.AddUserToBook)
+	}
 }


### PR DESCRIPTION
## Summary
- create `Book` model and controller
- allow Users to belong to many Books
- expose POST `/books` to create a book
- expose POST `/books/:id/users/:userId` to add users to a book
- expose GET `/books/:id` to fetch a book with its users
- document new routes in README

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_68850be8d86c832286bd09f971340fb4