### PR TITLE
Add book transactions linking and full book CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ User registration remains open at `POST /api/users`.
 
 Authenticated users can manage books:
 
+- `GET /api/books` – list all books.
 - `POST /api/books` – create a new book by providing a `title`.
-- `POST /api/books/{id}/users/{userId}` – add a user to a book.
 - `GET /api/books/{id}` – retrieve a book with its members.
+- `PUT /api/books/{id}` – update the book title.
+- `DELETE /api/books/{id}` – delete a book.
+- `POST /api/books/{id}/users/{userId}` – add a user to a book.
+
+### Transactions
+
+Transactions must specify which book they belong to:
+
+- `POST /api/transactions` – create a transaction using `amount`, `note`, `date`, `user_id`, `book_id` and `category_id`.
+- `GET /api/transactions` – list all transactions.
+- `GET /api/transactions/{id}` – retrieve a transaction.
+- `PUT /api/transactions/{id}` – update a transaction.
+- `DELETE /api/transactions/{id}` – remove a transaction.

--- a/controllers/book_controller.go
+++ b/controllers/book_controller.go
@@ -88,3 +88,70 @@ func AddUserToBook(c *gin.Context) {
 
 	c.JSON(http.StatusOK, models.JsonResponse{Success: true, Message: "User added to book.", Data: book})
 }
+
+// GetBooks godoc
+// @Summary Get all books
+// @Description ดึงข้อมูลหนังสือทั้งหมด
+// @Tags books
+// @Produce json
+// @Success 200 {array} models.JsonResponse
+// @Router /api/books [get]
+func GetBooks(c *gin.Context) {
+	var books []models.Book
+	if err := database.DB.Preload("Users").Find(&books).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to retrieve books."})
+		return
+	}
+	c.JSON(http.StatusOK, models.JsonResponse{Success: true, Message: "Books retrieved successfully.", Data: books})
+}
+
+// UpdateBook godoc
+// @Summary Update book title
+// @Description แก้ไขชื่อหนังสือ
+// @Tags books
+// @Accept json
+// @Produce json
+// @Param id path int true "Book ID"
+// @Param book body models.BookCreateRequest true "Book JSON"
+// @Success 200 {object} models.JsonResponse
+// @Router /api/books/{id} [put]
+func UpdateBook(c *gin.Context) {
+	id := c.Param("id")
+	var req models.BookCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.JsonResponse{Success: false, Message: "Invalid request data."})
+		return
+	}
+	var book models.Book
+	if err := database.DB.First(&book, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.JsonResponse{Success: false, Message: "Book not found."})
+		return
+	}
+	book.Title = req.Title
+	if err := database.DB.Save(&book).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to update book."})
+		return
+	}
+	c.JSON(http.StatusOK, models.JsonResponse{Success: true, Message: "Book updated successfully.", Data: book})
+}
+
+// DeleteBook godoc
+// @Summary Delete a book
+// @Description ลบหนังสือตาม ID
+// @Tags books
+// @Param id path int true "Book ID"
+// @Success 204 {object} models.JsonResponse
+// @Router /api/books/{id} [delete]
+func DeleteBook(c *gin.Context) {
+	id := c.Param("id")
+	var book models.Book
+	if err := database.DB.First(&book, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, models.JsonResponse{Success: false, Message: "Book not found."})
+		return
+	}
+	if err := database.DB.Delete(&book).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.JsonResponse{Success: false, Message: "Failed to delete book."})
+		return
+	}
+	c.JSON(http.StatusNoContent, models.JsonResponse{Success: true, Message: "Book deleted successfully."})
+}

--- a/controllers/transaction_controller.go
+++ b/controllers/transaction_controller.go
@@ -33,6 +33,7 @@ func CreateTransaction(c *gin.Context) {
 		Note:       request.Note,
 		Date:       request.Date,
 		UserID:     request.UserID,
+		BookID:     request.BookID,
 		CategoryID: request.CategoryID,
 	}
 
@@ -61,7 +62,7 @@ func CreateTransaction(c *gin.Context) {
 // @Router /api/transactions [get]
 func GetTransactions(c *gin.Context) {
 	var transactions []models.Transaction
-	if err := database.DB.Find(&transactions).Error; err != nil {
+	if err := database.DB.Preload("Book").Find(&transactions).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, models.JsonResponse{
 			Success: false,
 			Message: "Failed to retrieve transactions.",
@@ -112,6 +113,7 @@ func UpdateTransaction(c *gin.Context) {
 	transaction.Note = request.Note
 	transaction.Date = request.Date
 	transaction.UserID = request.UserID
+	transaction.BookID = request.BookID
 	transaction.CategoryID = request.CategoryID
 	if err := database.DB.Save(&transaction).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, models.JsonResponse{
@@ -172,7 +174,7 @@ func DeleteTransaction(c *gin.Context) {
 func GetTransaction(c *gin.Context) {
 	id := c.Param("id")
 	var transaction models.Transaction
-	if err := database.DB.First(&transaction, id).Error; err != nil {
+	if err := database.DB.Preload("Book").First(&transaction, id).Error; err != nil {
 		c.JSON(http.StatusNotFound, models.JsonResponse{
 			Success: false,
 			Message: "Transaction not found.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -43,6 +43,8 @@ definitions:
     properties:
       amount:
         type: number
+      book_id:
+        type: integer
       category_id:
         type: integer
       date:
@@ -52,15 +54,18 @@ definitions:
       user_id:
         type: integer
     required:
-    - amount
-    - category_id
-    - date
-    - user_id
+      - amount
+      - book_id
+      - category_id
+      - date
+      - user_id
     type: object
   models.TransactionUpdateRequest:
     properties:
       amount:
         type: number
+      book_id:
+        type: integer
       category_id:
         type: integer
       date:
@@ -70,10 +75,11 @@ definitions:
       user_id:
         type: integer
     required:
-    - amount
-    - category_id
-    - date
-    - user_id
+      - amount
+      - book_id
+      - category_id
+      - date
+      - user_id
     type: object
   models.TypeCreateRequest:
     properties:

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -7,29 +7,33 @@ import (
 )
 
 type Transaction struct {
-    ID         uint           `gorm:"primaryKey"`
-    Amount     float64        `gorm:"not null"`
-    Note       string         `gorm:"size:255"`
-    Date       time.Time      `gorm:"not null"`
-    UserID     uint
-    CategoryID uint
-    CreatedAt  time.Time
-    UpdatedAt  time.Time
-    DeletedAt  gorm.DeletedAt `gorm:"index"`
+	ID         uint      `gorm:"primaryKey"`
+	Amount     float64   `gorm:"not null"`
+	Note       string    `gorm:"size:255"`
+	Date       time.Time `gorm:"not null"`
+	UserID     uint
+	BookID     uint
+	CategoryID uint
+	Book       Book
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	DeletedAt  gorm.DeletedAt `gorm:"index"`
 }
 
 type TransactionCreateRequest struct {
-    Amount     float64 `json:"amount" binding:"required"`
-    Note       string  `json:"note"`
-    Date       time.Time `json:"date" binding:"required"`
-    UserID     uint    `json:"user_id" binding:"required"`
-    CategoryID uint    `json:"category_id" binding:"required"`
+	Amount     float64   `json:"amount" binding:"required"`
+	Note       string    `json:"note"`
+	Date       time.Time `json:"date" binding:"required"`
+	UserID     uint      `json:"user_id" binding:"required"`
+	BookID     uint      `json:"book_id" binding:"required"`
+	CategoryID uint      `json:"category_id" binding:"required"`
 }
 
 type TransactionUpdateRequest struct {
-    Amount     float64 `json:"amount" binding:"required"`
-    Note       string  `json:"note"`
-    Date       time.Time `json:"date" binding:"required"`
-    UserID     uint    `json:"user_id" binding:"required"`
-    CategoryID uint    `json:"category_id" binding:"required"`
+	Amount     float64   `json:"amount" binding:"required"`
+	Note       string    `json:"note"`
+	Date       time.Time `json:"date" binding:"required"`
+	UserID     uint      `json:"user_id" binding:"required"`
+	BookID     uint      `json:"book_id" binding:"required"`
+	CategoryID uint      `json:"category_id" binding:"required"`
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -58,8 +58,11 @@ func SetupRoutes(r *gin.Engine) {
 
 	book := auth.Group("/books")
 	{
+		book.GET("/", controllers.GetBooks)
 		book.POST("/", controllers.CreateBook)
 		book.GET("/:id", controllers.GetBook)
+		book.PUT("/:id", controllers.UpdateBook)
+		book.DELETE("/:id", controllers.DeleteBook)
 		book.POST("/:id/users/:userId", controllers.AddUserToBook)
 	}
 }


### PR DESCRIPTION
## Summary
- add `book_id` to transaction models and requests
- preload book data when reading transactions
- implement list, update, and delete for books
- expose new book routes
- document new endpoints and transaction field
- update swagger spec

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.4)*
- `go build ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6885147b44e88322ae5ff0bd689f61cb